### PR TITLE
gui: don't show embedded stage

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -3546,9 +3546,6 @@ GtkWidget *gui_init()
 	gui_fade_init(); 
     gui_spinner_init();
 
-    /* Show the stage */
-    clutter_actor_show(stage);
-
     /* Create a timeline to manage animation */
     clock_timeline = clutter_timeline_new(200);
 


### PR DESCRIPTION
Embedded stage visibility is driven by the embedding GtkWidget. Just call
gtk_widget_show() on the embedding widget instead.
